### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+folium
+matplotlib
+numpy
+pandas
+seaborn
+plotly==5.9.0


### PR DESCRIPTION
https://epistemix.atlassian.net/browse/PLAT-563

Band-aided [here](https://github.com/Epistemix-com/EpxPlatform-BaseDockerfile/pull/96).

MUST COMPLETE ALL OF THE BELOW:

- [ ] Re-add quickstart guide requirements.txt install call [here](https://github.com/Epistemix-com/EpxPlatform-BaseDockerfile/commit/3e7b3e8aa60ef8ccbc0f264fcf1cf01ff880ae55#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L91-L97). Demo models aren't in the base dockerfile anymore, but quickstart guide still is.
- [ ] Ensure packages listed here are actually used in the community library repo.
- [ ] Update base dockerfile (https://github.com/Epistemix-com/EpxPlatform-BaseDockerfile) to call pip install on this requirements.txt.
- [ ] Revert https://github.com/Epistemix-com/EpxPlatform-BaseDockerfile/pull/96