### PR TITLE
chore: remove versions from networkx because of conflict

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 pandas
 numpy
 matplotlib
-networkx>=3.4.2,<4.0 #align this version to match the version used in epx-client
+networkx
 folium
 jupyterlab
 plotly>=5.18.0,<6.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package requirements by removing version constraints on the networkx library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->